### PR TITLE
Broken build status badge in reaadme

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -4,3 +4,4 @@ Project Leads
 Committers
   Aniruddha Maru <https://github.com/maroux/>
   Ryan Chong <https://github.com/chongr/>
+  Jonathon Klobucar <https://github.com/klobucar>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hedwig Library for Go
 
-[![Build Status](https://travis-ci.org/Automatic/hedwig-go.svg?branch=master)](https://travis-ci.org/Automatic/hedwig-go)
+[![Build Status](https://travis-ci.com/Automatic/hedwig-go.svg?branch=master)](https://travis-ci.org/Automatic/hedwig-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Automatic/hedwig-go)](https://goreportcard.com/report/github.com/Automatic/hedwig-go)
 [![Godoc](https://godoc.org/github.com/Automatic/hedwig-go?status.svg)](http://godoc.org/github.com/Automatic/hedwig-go)
 [![Coverage](https://img.shields.io/coveralls/automatic/hedwig-go/master.svg?style=flat-square)](https://coveralls.io/r/automatic/hedwig-go)


### PR DESCRIPTION
Fix busted build status icon as travis-ci moved the domain from `.org` to `.com` for OSS projects.